### PR TITLE
chore: rename org

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -149,7 +149,7 @@ jobs:
           local max_retries=3
           local tag
           while [ $retries -lt $max_retries ]; do
-            tag=$(curl -L https://api.github.com/repos/janhq/cortex.llamacpp/releases/latest | jq -r .tag_name)
+            tag=$(curl -L https://api.github.com/repos/menloresearch/cortex.llamacpp/releases/latest | jq -r .tag_name)
             if [ -n "$tag" ] && [ "$tag" != "null" ]; then
               echo $tag
               return


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the file `.github/workflows/nightly.yml`. The change updates the GitHub repository URL used in the curl command to fetch the latest release tag.

Repository URL update:

* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L152-R152): Changed the repository URL from `janhq/cortex.llamacpp` to `menloresearch/cortex.llamacpp` in the curl command to fetch the latest release tag.