### PR TITLE
chore: fix windows build

### DIFF
--- a/src/llama_engine.cc
+++ b/src/llama_engine.cc
@@ -594,7 +594,7 @@ bool LlamaEngine::LoadModelImpl(std::shared_ptr<Json::Value> json_body) {
 #if defined(_WIN32)
       std::wstring mp_ws = Utf8ToWstring(model_path.asString());
       if (std::filesystem::exists(std::filesystem::path(mp_ws))) {
-        params.model = WstringToUtf8(mp_ws);
+        params.model.path = WstringToUtf8(mp_ws);
 #else
       if (std::filesystem::exists(
               std::filesystem::path(model_path.asString()))) {


### PR DESCRIPTION
This pull request includes a minor update to the `LlamaEngine::LoadModelImpl` method in `src/llama_engine.cc`. The change modifies how the `params.model` is assigned to ensure the `path` attribute is explicitly set.

* [`src/llama_engine.cc`](diffhunk://#diff-bca4ec26627d57d17c75e7c3d0f21accaf4c5b8e18eb2536ef2e3a6d3d32855bL597-R597): Updated `params.model` to `params.model.path` for clarity and correctness in the Windows-specific code path.