### PR TITLE
Update llama.cpp submodule to latest release b5277

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CORTEXLLAMA_VERSION)
   add_compile_definitions(CORTEXLLAMA_VERSION="${CORTEXLLAMA_VERSION}")
 endif()
 
-add_subdirectory(llama.cpp/examples/llava)
+add_subdirectory(llama.cpp/tools/llava)
 add_subdirectory(llama.cpp)
 
 add_library(${TARGET} SHARED


### PR DESCRIPTION
This PR updates the llama.cpp submodule to the latest release: b5277.